### PR TITLE
fixes issues when there is no CSS3 transition

### DIFF
--- a/js/slider.js
+++ b/js/slider.js
@@ -64,7 +64,7 @@ if ( 'querySelector' in document && 'addEventListener' in window ) {
 		var slides, slidePos, width, length;
 		options = options || {};
 		var index = parseInt(options.startSlide - 1, 10) || 0;
-		var speed = options.speed || 300;
+		var speed = options.speed !== undefined ? options.speed : 300;
 		options.continuous = options.continuous !== undefined ? options.continuous : true;
 
 		var setup = function () {
@@ -211,6 +211,10 @@ if ( 'querySelector' in document && 'addEventListener' in window ) {
 			if (!speed) {
 
 				element.style.left = to + 'px';
+
+				visibleThree(index, slides);
+				options.transitionEnd && options.transitionEnd.call(event, index, slides[index]);
+
 				return;
 
 			}


### PR DESCRIPTION
In IE9 the classes of the slides would not get updated, so the slider failed with more than 3 slides. The method call to 'visibleThree' was missing. While I added this, I also noticed it missing from the if-statement that was called when speed was set to 0.
