### PR TITLE
fixes transitions with speed = 0

### DIFF
--- a/js/slider.js
+++ b/js/slider.js
@@ -196,7 +196,7 @@ if ( 'querySelector' in document && 'addEventListener' in window ) {
 			style.MozTransitionDuration =
 			style.msTransitionDuration =
 			style.OTransitionDuration =
-			style.transitionDuration = speed + 'ms';
+			style.transitionDuration = (speed || 1) + 'ms';
 
 			style.webkitTransform = 'translate(' + dist + 'px,0)' + 'translateZ(0)';
 			style.msTransform =


### PR DESCRIPTION
By allowing zero speed I introduced a small bug in my last pull request.
When speed==0 the transitionEnd-event is not fired and the slider won't update. This commit sets the minimum speed to 1ms.
